### PR TITLE
Changed Version Update Swagger Request Validator Core and Jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
       <dependency>
          <groupId>com.atlassian.oai</groupId>
          <artifactId>swagger-request-validator-core</artifactId>
-         <version>2.11.0</version> 
+         <version>2.36.0</version> 
       </dependency>
 		<dependency>
 			<groupId>org.slf4j</groupId>
@@ -86,13 +86,13 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>2.13.2</version>
+			<version>2.15.2</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.13.2.1</version>
+			<version>2.15.2</version>
 			<scope>provided</scope>
 		</dependency>
       


### PR DESCRIPTION
After some Validation Errors we updated the dependencies to allow newer specification files.
Changed the Versions of Validator Core , Jackson Core and Jackson Data.